### PR TITLE
Raise when Encountering Unexpected Responses

### DIFF
--- a/linode/__init__.py
+++ b/linode/__init__.py
@@ -1,5 +1,5 @@
 from linode.objects import *
-from linode.api import ApiError
+from linode.errors import ApiError, UnexpectedResponseError
 from linode.util import *
 from linode.linode_client import LinodeClient
 from linode.login_client import LinodeLoginClient, OAuthScopes

--- a/linode/api.py
+++ b/linode/api.py
@@ -1,6 +1,0 @@
-from linode import mappings
-
-class ApiError(RuntimeError):
-    def __init__(self, message, status=400):
-        super(RuntimeError, self).__init__(message)
-        self.status=status

--- a/linode/errors.py
+++ b/linode/errors.py
@@ -1,0 +1,25 @@
+from linode import mappings
+
+class ApiError(RuntimeError):
+    """
+    An API Error is any error returned from the API.  These
+    typically have a status code in the 400s or 500s.  Most
+    often, this will be caused by invalid input to the API.
+    """
+    def __init__(self, message, status=400, json=None):
+        super(RuntimeError, self).__init__(message)
+        self.status = status
+        self.json = json
+
+class UnexpectedResponseError(RuntimeError):
+    """
+    An Unexpected Response Error occurs when the API returns
+    something that this library is unable to parse, usually
+    because it expected something specific and didn't get it.
+    These typically indicate an oversight in developing this
+    library, and should be fixed with changes to this codebase.
+    """
+    def __init__(self, message, status=200, json=None):
+        super(RuntimeError, self).__init__(message)
+        self.status = status
+        self.json = json

--- a/linode/linode_client.py
+++ b/linode/linode_client.py
@@ -2,7 +2,7 @@ import requests
 import json
 from datetime import datetime
 
-from linode.api import ApiError
+from linode.errors import ApiError, UnexpectedResponseError
 from linode import mappings
 from linode.objects import *
 from linode.objects.filtering import Filter
@@ -74,7 +74,7 @@ class LinodeGroup(Group):
         result = self.client.post('/linode/instances', data=params)
 
         if not 'id' in result:
-            return result
+            raise UnexpectedResponseError('Unexpected response when creating linode!', json=result)
 
         l = Linode(self.client, result['id'])
         l._populate(result)
@@ -116,7 +116,7 @@ class LinodeGroup(Group):
         result = self.client.post('/linode/stackscripts', data=params)
 
         if not 'id' in result:
-            return result
+            raise UnexpectedResponseError('Unexpected response when creating StackScript!', json=result)
 
         s = StackScript(self.client, result['id'])
         s._populate(result)
@@ -136,7 +136,7 @@ class DnsGroup(Group):
         result = self.client.post('/dns/zones', data=params)
 
         if not 'id' in result:
-            return result
+            raise UnexpectedResponseError('Unexpected response when creating DNS Zone!', json=result)
 
         z = DnsZone(self.client, result['id'])
         z._populate(result)
@@ -161,7 +161,7 @@ class AccountGroup(Group):
         result = self.client.get('/account/profile')
 
         if not 'username' in result:
-            return result
+            raise UnexpectedResponseError('Unexpected response when getting profile!', json=result)
 
         p = Profile(self.client, result['username'])
         p._populate(result)
@@ -175,7 +175,8 @@ class AccountGroup(Group):
         result = self.client.get('/account/settings')
 
         if not 'email' in result:
-            return result
+            raise UnexpectedResponseError('Unexpected response when getting account settings!',
+                    json=result)
 
         s = AccountSettings(self.client, result['email'])
         s._populate(result)
@@ -200,7 +201,8 @@ class AccountGroup(Group):
         result = self.client.post('/account/clients', data=params)
 
         if not 'id' in result:
-            return result
+            raise UnexpectedResponseError('Unexpected response when creating OAuth Client!',
+                    json=result)
 
         c = OAuthClient(self.client, result['id'])
         c._populate(result)
@@ -228,7 +230,8 @@ class AccountGroup(Group):
         result = self.client.post('/account/tokens', data=kwargs)
 
         if not 'id' in result:
-            return result
+            raise UnexpectedResponseError('Unexpected response when creating Personal Access '
+                    'Token!', json=result)
 
         t = OAuthToken(self.client, result['id'])
         t._populate(result)
@@ -268,7 +271,8 @@ class NetworkingGroup(Group):
         })
 
         if not 'ips' in result:
-            return result
+            raise UnexpectedResponseError('Unexpected response when assigning IPs!',
+                    json=result)
 
         ips = []
         for r in result['ips']:
@@ -324,7 +328,7 @@ class LinodeClient:
                                 if 'reason' in e.keys() else ''
             except:
                 pass
-            raise ApiError(error_msg, status=r.status_code)
+            raise ApiError(error_msg, status=r.status_code, json=j)
 
         j = r.json()
 

--- a/linode/login_client.py
+++ b/linode/login_client.py
@@ -1,6 +1,6 @@
 import requests
 from enum import Enum
-from linode.api import ApiError
+from linode.errors import ApiError
 
 try:
     from urllib.parse import urlparse

--- a/linode/objects/account/profile.py
+++ b/linode/objects/account/profile.py
@@ -1,3 +1,4 @@
+from ...errors import UnexpectedResponseError
 from linode.objects import Base, Property
 
 class Profile(Base):
@@ -32,9 +33,6 @@ class Profile(Base):
         """
         result = self._client.post('/account/profile/tfa-enable')
 
-        if 'errors' in result:
-            return result
-
         return result['secret']
 
     def confirm_tfa(self, code):
@@ -45,9 +43,6 @@ class Profile(Base):
             "tfa-code": code
         })
 
-        if 'errors' in result:
-            return result
-
         return True
 
     def disable_tfa(self):
@@ -55,8 +50,5 @@ class Profile(Base):
         Turns off TFA for this user's account.
         """
         result = self._client.post('/account/profile/tfa-disable')
-
-        if 'errors' in result:
-            return result
 
         return True

--- a/linode/objects/dbase.py
+++ b/linode/objects/dbase.py
@@ -1,5 +1,5 @@
 from .base import Base
-from .. import api
+from .. import errors
 
 class DerivedBase(Base):
     """

--- a/linode/objects/dns/zone.py
+++ b/linode/objects/dns/zone.py
@@ -1,3 +1,4 @@
+from ...errors import UnexpectedResponseError
 from linode.objects import Base, Property
 from .record import DnsZoneRecord
 
@@ -32,7 +33,7 @@ class DnsZone(Base):
         self.invalidate()
 
         if not 'id' in result:
-            return result
+            raise UnexpectedResponseError('Unexpected response creating zone record!', json=result)
 
         zr = DnsZoneRecord(self._client, result['id'], self.id)
         zr._populate(result)

--- a/linode/objects/linode/disk.py
+++ b/linode/objects/linode/disk.py
@@ -1,3 +1,4 @@
+from ...errors import UnexpectedResponseError
 from .. import DerivedBase, Property
 
 class Disk(DerivedBase):
@@ -22,7 +23,7 @@ class Disk(DerivedBase):
         result = self._client.post(Disk.api_endpoint, model=self, data={})
 
         if not 'id' in result:
-            return result
+            raise UnexpectedResponseError('Unexpected response duplicating disk!', json=result)
 
         d = Disk(self._client, result['id'], self.linode_id)
         d._populate(result)
@@ -42,9 +43,7 @@ class Disk(DerivedBase):
         result = self._client.post(Disk.api_endpoint, model=self, data=params)
 
         if not 'id' in result:
-            if not root_password:
-                return result, rpass
-            return result
+            raise UnexpectedResponseError('Unexpected response duplicating disk!', json=result)
 
         self._populate(result)
         if not root_password:


### PR DESCRIPTION
Throughout the library we handle the case where the API responds
with something other than what we expected.  Previously, this was
handled by returning the JSON that the API gave us, instead of doing
anything with it like we would have if it was what we expected it
would be.  However, this behavior could be problematic - if code
was written expecting an object back, and instead it received a dict,
it would break in non-obvious ways.  To solve this, we could raise
anytime an unexpected response is received, making it immediately
obvious what went wrong.

On the other hand, if the response was being discarded anyway, this
change would cause code to break that otherwise would have worked.

This should only ever happen if the library is not written correctly,
or is not up to date with the API.  In normal circumstances, these
errors should never be encountered.