### PR TITLE
Fix some links

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,6 +32,6 @@ Examples
 See the `Install on a Linode`_ example project for a simple use case demonstrating
 many of the features of this library.
 
-.. _Linode API v4: https://developers.linode.com
+.. _Linode API v4: https://developers.linode.com/v4/introduction
 .. _Install on a Linode: https://github.com/linode/python-api/tree/master/examples/install-on-linode
-.. _Python Reference: https://developers.linode.com/guides/python
+.. _Python Reference: https://developers.linode.com/v4/guides/python


### PR DESCRIPTION
I figure we may as well send them straight to /v4/introduction since they're getting sent there anyway, also fixes the broken Python reference link again