### PR TITLE
Add support for POST /networking/ipv4

### DIFF
--- a/linode/linode_client.py
+++ b/linode/linode_client.py
@@ -283,6 +283,19 @@ class NetworkingGroup(Group):
             ips.append(i)
 
         return ips
+    
+    def allocate_ip(self, linode):
+        result = self.client.post('/networking/ipv4/', data={
+            "linode": linode.id if isinstance(linode, Base) else linode,
+        })
+
+        if not 'address' in result:
+             raise UnexpectedResponseError('Unexpected response when adding IPv4 address!',
+                     json=result)
+
+        ip = IPAddress(self.client, result['address'])
+        ip._populate(result)
+        return ip
 
 class SupportGroup(Group):
     def get_tickets(self, *filters):


### PR DESCRIPTION
Some thoughts:

- Using "create" as the verb sorta follows what we do elsewhere, but I think add is more fitting here, because you aren't creating the IP

- I think it's okay that we're not specifying IPv4 vs IPv6 in the name, like with assign_ips, since you can't add IPv6 addresses on your own

- ```linode_id=None``` is just so we can provide a better error than ```TypeError: add_ip() missing 1 required positional argument: 'linode_id'``` ... can remove it if we don't want to do that