### PR TITLE
Fix disk property name. Was state, should be status.

### DIFF
--- a/linode/objects/linode/disk.py
+++ b/linode/objects/linode/disk.py
@@ -12,7 +12,7 @@ class Disk(DerivedBase):
         'created': Property(is_datetime=True),
         'label': Property(mutable=True, filterable=True),
         'size': Property(filterable=True),
-        'state': Property(filterable=True),
+        'status': Property(filterable=True),
         'filesystem': Property(),
         'updated': Property(is_datetime=True),
         'linode_id': Property(identifier=True),


### PR DESCRIPTION
disk.state was returning None for all disks. Looking at the [API docs](https://developers.linode.com/v4/reference/endpoints/linode/instances/:id/disks/:id), the property should be named status. Changing the name to status got me the correct values.