### PR TITLE
Travis support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: python
+python:
+    - "2.7"
+    - "3.3"
+    - "3.4"
+    - "3.5"
+    - "3.6"
+install:
+    - python setup.py install
+script:
+    - python setup.py test

--- a/README.rst
+++ b/README.rst
@@ -3,6 +3,9 @@ python-linode-api
 
 The official python library for the `Linode API v4`_ in python.
 
+.. image:: https://travis-ci.org/linode/python-linode-api.svg?branch=master
+    :target: https://travis-ci.org/linode/python-linode-api
+
 Installation
 ------------
 ::


### PR DESCRIPTION
Adds support for testing against Travis CI.  This will ensure that the
library at least works against all supported python versions, and
ideally will grow to include unit tests for most things once the api has
stabilized enough for adding mock responses to make sense.