### PR TITLE
Rename Token to OAuthToken

### DIFF
--- a/linode/linode_client.py
+++ b/linode/linode_client.py
@@ -168,7 +168,7 @@ class ProfileGroup(Group):
         """
         Returns the Person Access Tokens active for this user
         """
-        return self.client._get_and_filter(OAuthToken, *filters)
+        return self.client._get_and_filter(PersonalAccessToken, *filters)
 
     def create_personal_access_token(self, label=None, expiry=None, scopes=None, **kwargs):
         """
@@ -189,8 +189,8 @@ class ProfileGroup(Group):
             raise UnexpectedResponseError('Unexpected response when creating Personal Access '
                     'Token!', json=result)
 
-        t = OAuthToken(self.client, result['id'], result)
-        return t
+        token = PersonalAccessToken(self.client, result['id'], result)
+        return token
 
     def get_apps(self, *filters):
         """

--- a/linode/linode_client.py
+++ b/linode/linode_client.py
@@ -168,7 +168,7 @@ class ProfileGroup(Group):
         """
         Returns the Person Access Tokens active for this user
         """
-        return self.client._get_and_filter(Token, *filters)
+        return self.client._get_and_filter(OAuthToken, *filters)
 
     def create_personal_access_token(self, label=None, expiry=None, scopes=None, **kwargs):
         """

--- a/linode/objects/profile/__init__.py
+++ b/linode/objects/profile/__init__.py
@@ -1,4 +1,4 @@
-from .oauth_token import Token
+from .oauth_token import OAuthToken
 from .app import AuthorizedApp
 from .profile import Profile
 from .whitelist_entry import WhitelistEntry

--- a/linode/objects/profile/__init__.py
+++ b/linode/objects/profile/__init__.py
@@ -1,4 +1,4 @@
-from .oauth_token import OAuthToken
+from .personal_access_token import PersonalAccessToken
 from .app import AuthorizedApp
 from .profile import Profile
 from .whitelist_entry import WhitelistEntry

--- a/linode/objects/profile/oauth_token.py
+++ b/linode/objects/profile/oauth_token.py
@@ -1,6 +1,6 @@
 from linode.objects import Base, Property
 
-class Token(Base):
+class OAuthToken(Base):
     api_endpoint = "/profile/tokens/{id}"
 
     properties = {

--- a/linode/objects/profile/personal_access_token.py
+++ b/linode/objects/profile/personal_access_token.py
@@ -1,6 +1,6 @@
 from linode.objects import Base, Property
 
-class OAuthToken(Base):
+class PersonalAccessToken(Base):
     api_endpoint = "/profile/tokens/{id}"
 
     properties = {


### PR DESCRIPTION
There were references to OAuthToken in linode_client.py, which for one is undefined so this cannot work, and other classes followed the pattern of camel_case_obj.py contains class CamelCaseObj.