### PR TITLE
Follows API with GET /account/settings changes

### DIFF
--- a/linode/linode_client.py
+++ b/linode/linode_client.py
@@ -234,11 +234,11 @@ class AccountGroup(Group):
         """
         result = self.client.get('/account/settings')
 
-        if not 'email' in result:
+        if not 'managed' in result:
             raise UnexpectedResponseError('Unexpected response when getting account settings!',
                     json=result)
 
-        s = AccountSettings(self.client, result['email'], result)
+        s = AccountSettings(self.client, result['managed'], result)
         return s
 
     def get_invoices(self):
@@ -520,6 +520,17 @@ class LinodeClient:
 
         p = Profile(self, result['username'], result)
         return p
+
+    def get_account(self):
+        """
+        Returns account billing information
+        """
+        result = self.get('/account')
+
+        if not 'email' in result:
+            raise UnexpectedResponseError('Unexpected response when getting account!', json=result)
+
+        return Account(self, result['email'], result)
 
     def get_images(self, *filters):
         return self._get_and_filter(Image, *filters)

--- a/linode/objects/account/__init__.py
+++ b/linode/objects/account/__init__.py
@@ -6,3 +6,4 @@ from .user_grant import UserGrants
 from .invoice import Invoice
 from .invoiceitem import InvoiceItem
 from .payment import Payment
+from .account import Account

--- a/linode/objects/account/account.py
+++ b/linode/objects/account/account.py
@@ -1,0 +1,24 @@
+from __future__ import absolute_import
+
+from linode.objects import Base, Property
+
+
+class Account(Base):
+    api_endpoint = "/account"
+    id_attribute = 'email'
+
+    properties = {
+        "company": Property(mutable=True),
+        "country": Property(mutable=True),
+        "balance": Property(),
+        "address_1": Property(mutable=True),
+        "last_name": Property(mutable=True),
+        "city": Property(mutable=True),
+        "state": Property(mutable=True),
+        "first_name": Property(mutable=True),
+        "phone": Property(mutable=True),
+        "email": Property(mutable=True),
+        "zip": Property(mutable=True),
+        "address_2": Property(mutable=True),
+        "vat_number": Property(mutable=True),
+    }

--- a/linode/objects/account/settings.py
+++ b/linode/objects/account/settings.py
@@ -1,26 +1,15 @@
 from __future__ import absolute_import
 
 from linode.objects import Base, Property
+from linode.objects.longview import LongviewSubscription
 
 
 class AccountSettings(Base):
     api_endpoint = "/account/settings"
-    id_attribute = 'email'
+    id_attribute = 'managed' # this isn't actually used
 
     properties = {
-        "company": Property(mutable=True),
-        "country": Property(mutable=True),
-        "balance": Property(),
-        "address_1": Property(mutable=True),
         "network_helper": Property(mutable=True),
-        "last_name": Property(mutable=True),
-        "city": Property(mutable=True),
-        "state": Property(mutable=True),
-        "first_name": Property(mutable=True),
-        "phone": Property(mutable=True),
         "managed": Property(),
-        "email": Property(mutable=True),
-        "zip": Property(mutable=True),
-        "address_2": Property(mutable=True),
-        "vat_number": Property(mutable=True),
+        "longview_subscription": Property(slug_relationship=LongviewSubscription)
     }

--- a/test/fixtures/account.json
+++ b/test/fixtures/account.json
@@ -1,0 +1,15 @@
+{
+  "state": "PA",
+  "city": "Philadelphia",
+  "phone": "123-456-7890",
+  "vat_number": "",
+  "balance": 0,
+  "company": "Linode",
+  "address_2": "",
+  "email": "support@linode.com",
+  "address_1": "3rd & Arch St",
+  "zip": "19106",
+  "first_name": "Test",
+  "last_name": "Guy",
+  "country": "US"
+}

--- a/test/fixtures/account_settings.json
+++ b/test/fixtures/account_settings.json
@@ -1,0 +1,5 @@
+{
+  "longview_subscription": "longview-100",
+  "managed": false,
+  "network_helper": false
+}

--- a/test/linode_client_test.py
+++ b/test/linode_client_test.py
@@ -1,10 +1,30 @@
 from test.base import ClientBaseCase
 
+from linode import LongviewSubscription
+
 
 class LinodeClientGeneralTest(ClientBaseCase):
     """
     Tests methods of the LinodeClient class that do not live inside of a group.
     """
+    def test_get_account(self):
+        a = self.client.get_account()
+        self.assertEqual(a._populated, True)
+
+        self.assertEqual(a.first_name, 'Test')
+        self.assertEqual(a.last_name, 'Guy')
+        self.assertEqual(a.email, 'support@linode.com')
+        self.assertEqual(a.phone, '123-456-7890')
+        self.assertEqual(a.company, 'Linode')
+        self.assertEqual(a.address_1, '3rd & Arch St')
+        self.assertEqual(a.address_2, '')
+        self.assertEqual(a.city, 'Philadelphia')
+        self.assertEqual(a.state, 'PA')
+        self.assertEqual(a.country, 'US')
+        self.assertEqual(a.zip, '19106')
+        self.assertEqual(a.vat_number, '')
+        self.assertEqual(a.balance, 0)
+
     def test_get_regions(self):
         r = self.client.get_regions()
 
@@ -30,6 +50,23 @@ class LinodeClientGeneralTest(ClientBaseCase):
         self.assertEqual(v[0].region.id, 'us-east-1a')
         self.assertEqual(v[1].label, 'block2')
         self.assertEqual(v[1].size, 100)
+
+
+class AccountGroupTest(ClientBaseCase):
+    """
+    Tests methods of the AccountGroup
+    """
+    def test_get_settings(self):
+        """
+        Tests that account settings can be retrieved.
+        """
+        s = self.client.account.get_settings()
+        self.assertEqual(s._populated, True)
+
+        self.assertEqual(s.network_helper, False)
+        self.assertEqual(s.managed, False)
+        self.assertEqual(type(s.longview_subscription), LongviewSubscription)
+        self.assertEqual(s.longview_subscription.id, 'longview-100')
 
 
 class LinodeGroupTest(ClientBaseCase):


### PR DESCRIPTION
Now, LinodeClient.account.get_settings only returns settings, and
LinodeClient.get_account returns billing information and balance.