### PR TITLE
Followed API changes to NodeBalancer Configs

### DIFF
--- a/test/fixtures/nodebalancers.json
+++ b/test/fixtures/nodebalancers.json
@@ -1,0 +1,29 @@
+{
+  "data": [
+    {
+      "created": "2018-01-01T00:01:01",
+      "ipv6": "c001:d00d:b01::1:abcd:1234",
+      "region": "us-east-1a",
+      "ipv4": "12.34.56.789",
+      "hostname": "nb-12-34-56-789.newark.nodebalancer.linode.com",
+      "id": 123456,
+      "updated": "2018-01-01T00:01:01",
+      "label": "balancer123456",
+      "client_conn_throttle": 0
+    },
+    {
+      "created": "2018-01-01T00:01:01",
+      "ipv6": "c001:d00d:b01::1:abcd:1256",
+      "region": "us-east-1a",
+      "ipv4": "12.34.56.890",
+      "hostname": "nb-12-34-56-890.newark.nodebalancer.linode.com",
+      "id": 123457,
+      "updated": "2018-01-01T00:01:01",
+      "label": "balancer123457",
+      "client_conn_throttle": 0
+    }
+  ],
+  "results": 2,
+  "page": 1,
+  "pages": 1
+}

--- a/test/fixtures/nodebalancers_123456_configs.json
+++ b/test/fixtures/nodebalancers_123456_configs.json
@@ -1,0 +1,31 @@
+{
+  "data": [
+    {
+      "check": "connection",
+      "check_attempts": 2,
+      "stickiness": "table",
+      "check_interval": 5,
+      "check_body": "",
+      "id": 65432,
+      "check_passive": true,
+      "algorithm": "roundrobin",
+      "check_timeout": 3,
+      "check_path": "/",
+      "ssl_cert": null,
+      "ssl_commonname": "",
+      "port": 80,
+      "nodebalancer_id": 123456,
+      "cipher_suite": "recommended",
+      "ssl_key": null,
+      "nodes_status": {
+        "up": 0,
+        "down": 0
+      },
+      "protocol": "http",
+      "ssl_fingerprint": ""
+    }
+  ],
+  "results": 1,
+  "page": 1,
+  "pages": 1
+}

--- a/test/objects/nodebalancers/configs_test.py
+++ b/test/objects/nodebalancers/configs_test.py
@@ -1,0 +1,40 @@
+from datetime import datetime
+
+from test.base import ClientBaseCase
+from linode.objects.base import MappedObject
+
+from linode.objects import NodeBalancerConfig
+
+
+class NodeBalancerConfigTest(ClientBaseCase):
+    """
+    Tests methods of the NodeBalancerConfig class
+    """
+    def test_get_config(self):
+        """
+        Tests that a config is loaded correctly by ID
+        """
+        config = NodeBalancerConfig(self.client, 65432, 123456)
+        self.assertEqual(config._populated, False)
+
+        self.assertEqual(config.port, 80)
+        self.assertEqual(config._populated, True)
+
+        self.assertEqual(config.check, "connection")
+        self.assertEqual(config.protocol, "http")
+        self.assertEqual(config.check_attempts, 2)
+        self.assertEqual(config.stickiness, "table")
+        self.assertEqual(config.check_interval, 5)
+        self.assertEqual(config.check_body, "")
+        self.assertEqual(config.check_passive, True)
+        self.assertEqual(config.algorithm, "roundrobin")
+        self.assertEqual(config.check_timeout, 3)
+        self.assertEqual(config.check_path, "/")
+        self.assertEqual(config.ssl_cert, None)
+        self.assertEqual(config.ssl_commonname, "")
+        self.assertEqual(config.nodebalancer_id, 123456)
+        self.assertEqual(config.cipher_suite, "recommended")
+        self.assertEqual(config.ssl_key, None)
+        self.assertEqual(config.nodes_status.up, 0)
+        self.assertEqual(config.nodes_status.down, 0)
+        self.assertEqual(config.ssl_fingerprint, "")


### PR DESCRIPTION
Setting SSL is now done through a PUT - the old ssl method was turned
into a convenience method to allow easier populating of certs from
files.