### PR TITLE
Matched API changed for 2018-04-02 release

### DIFF
--- a/linode/linode_client.py
+++ b/linode/linode_client.py
@@ -570,13 +570,15 @@ class NetworkingGroup(Group):
             "assignments": [ a for a in assignments ],
         })
 
-    def allocate_ip(self, linode):
+    def allocate_ip(self, linode, public=True):
         """
         Allocates an IP to a Linode you own.  Additional IPs must be requested
         by opening a support ticket first.
 
         :param linode: The Linode to allocate the new IP for.
         :type linode: Linode or int
+        :param public: If True, allocate a public IP address.  Defaults to True.
+        :type public: bool
 
         :returns: The new IPAddress
         :rtype: IPAddress

--- a/linode/objects/account/event.py
+++ b/linode/objects/account/event.py
@@ -8,7 +8,7 @@ from linode.objects.support.ticket import SupportTicket
 class Event(Base):
     api_endpoint = '/account/events/{id}'
     properties = {
-        'id': Property(identifier=True),
+        'id': Property(identifier=True, filterable=True),
         'percent_complete': Property(volatile=True),
         'created': Property(is_datetime=True, filterable=True),
         'updated': Property(is_datetime=True, filterable=True),

--- a/linode/objects/account/user.py
+++ b/linode/objects/account/user.py
@@ -8,7 +8,7 @@ class User(Base):
     id_attribute = 'username'
 
     properties = {
-        'email': Property(mutable=True),
+        'email': Property(),
         'username': Property(identifier=True, mutable=True),
         'restricted': Property(mutable=True),
     }

--- a/linode/objects/linode/linode.py
+++ b/linode/objects/linode/linode.py
@@ -321,7 +321,7 @@ class Linode(Base):
 
         .. _Backups Page: https://www.linode.com/backups
         """
-        result = self._client.post("{}/backups/enable".format(Linode.api_endpoint), model=self)
+        self._client.post("{}/backups/enable".format(Linode.api_endpoint), model=self)
         self.invalidate()
         return True
 
@@ -331,7 +331,7 @@ class Linode(Base):
         including any snapshots that have been taken.  This cannot be undone,
         but Backups can be re-enabled at a later date.
         """
-        result = self._client.post("{}/backups/cancel".format(Linode.api_endpoint), model=self)
+        self._client.post("{}/backups/cancel".format(Linode.api_endpoint), model=self)
         self.invalidate()
         return True
 

--- a/linode/objects/networking/ipaddress.py
+++ b/linode/objects/networking/ipaddress.py
@@ -13,6 +13,7 @@ class IPAddress(Base):
         "subnet_mask": Property(),
         "prefix": Property(),
         "type": Property(),
+        "public": Property(),
         "rdns": Property(mutable=True),
         "linode_id": Property(),
         "region": Property(slug_relationship=Region, filterable=True),

--- a/test/objects/linode/linode_test.py
+++ b/test/objects/linode/linode_test.py
@@ -29,13 +29,7 @@ class LinodeTest(ClientBaseCase):
         """
         linode = Linode(self.client, 123)
 
-        # barebones result of a rebuild
-        result = {
-            "config": [],
-            "disks": []
-        }
-
-        with self.mock_post(result) as m:
+        with self.mock_post('/linode/instances/123') as m:
             pw = linode.rebuild('linode/debian9')
 
             self.assertIsNotNone(pw)


### PR DESCRIPTION
* Moved endpoints for networking actions
* Change IPAddress object schema
* Stopped accepting password  for create_user
* Changed Linode.ips response structure
* Handled new responses from action endpoints

Also added sphinx-compliant docstrings where applicable.